### PR TITLE
Update OpenID Discovery to validate Authorization Endpoint is valid

### DIFF
--- a/Source/OIDServiceDiscovery.m
+++ b/Source/OIDServiceDiscovery.m
@@ -145,7 +145,7 @@ static NSString *const kOPTosURIKey = @"op_tos_uri";
 
   // Check required URL fields are valid URLs.
   NSArray *requiredURLFields = @[
-    kIssuerKey,
+    kAuthorizationEndpointKey,
     kTokenEndpointKey,
     kJWKSURLKey
   ];


### PR DESCRIPTION
I've read through the spec, and technically it is the authorization server that needs to be validated as resolvable and not the issuer. I don't see where it is required that the issuer == authorization server.

This is actually a problem for Microsoft, because we support multiple tenants and therefore discovery endpoints and issuers that are anonymous at first, particularly using the `/common`, `/orgaizations`, `/consumer` discovery endpoints. This results in correct authorization and token endpoints, but results in an issuer being a placeholder `{tenant id}`. 

As an example, here is the JSON returned from calling our `/common` endpoint:

```
{"authorization_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/authorize","token_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/token","token_endpoint_auth_methods_supported":["client_secret_post","private_key_jwt"],"jwks_uri":"https://login.microsoftonline.com/common/discovery/v2.0/keys","response_modes_supported":["query","fragment","form_post"],"subject_types_supported":["pairwise"],"id_token_signing_alg_values_supported":["RS256"],"http_logout_supported":true,"frontchannel_logout_supported":true,"end_session_endpoint":"https://login.microsoftonline.com/common/oauth2/v2.0/logout","response_types_supported":["code","id_token","code id_token","id_token token"],"scopes_supported":["openid","profile","email","offline_access"],"issuer":"https://login.microsoftonline.com/{tenantid}/v2.0","claims_supported":["sub","iss","cloud_instance_name","aud","exp","iat","auth_time","acr","nonce","preferred_username","name","tid","ver","at_hash","c_hash","email"],"request_uri_parameter_supported":false,"tenant_region_scope":null,"cloud_instance_name":"microsoftonline.com","cloud_graph_host_name":"graph.windows.net"}
```